### PR TITLE
Better Handle malformed comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .env
 private-key.pem
+scratch.js
+notes/

--- a/index.js
+++ b/index.js
@@ -45,15 +45,23 @@ module.exports = robot => {
     const freeze = new Freeze(context.github, config);
 
     context.github.search.issues({q:'label:' + freeze.config.labelName, repo:context.repo().full_name}).then(resp => {
-      resp.data.items.forEach(issue => {
-        context.github.issues.getComments(githubHelper.parseCommentURL(issue.comments_url)).then(resp => {
-          return freeze.getLastFreeze(resp.data);
-        }).then(lastFreezeComment => {
-          if (freeze.unfreezable(lastFreezeComment)) {
-            freeze.unfreeze(issue, formatParser.propFromComment(lastFreezeComment));
-          }
+      if (resp.data.total_count > 0) {
+        resp.data.items.forEach(issue => {
+          context.github.issues.getComments(githubHelper.parseCommentURL(issue.comments_url)).then(resp => {
+            return freeze.getLastFreeze(resp.data);
+          }).then(lastFreezeComment => {
+            if (Object.prototype.hasOwnProperty.call(lastFreezeComment, 'body')) {
+              if (freeze.unfreezable(lastFreezeComment)) {
+                freeze.unfreeze(issue, formatParser.propFromComment(lastFreezeComment));
+              }
+            } else {
+              robot.log(new Date() + ': ' + issue.comments_url + ' didn\'t find the snooze comment');
+            }
+          });
         });
-      });
+      } else {
+        console.log(new Date() + ': No issues found to thaw at this time');
+      }
     });
     console.log('scheduled thaw run complete');
   }

--- a/test/index.js
+++ b/test/index.js
@@ -57,12 +57,15 @@ perform: true
       },
       search: {
         issues: expect.createSpy().andReturn(Promise.resolve({
-          data:{items: [{comments_url:'https://api.github.com/repos/baxterthehacker/public-repo/issues/2/comments',
-            labels:[{
-              url: 'https://api.github.com/repos/baxterthehacker/public-repo/labels/probot:freeze',
-              name: 'probot:freeze',
-              color: 'fc2929'
-            }]}]
+          data:{
+            total_count: 1,
+            incomplete_results: false,
+            items: [{comments_url:'https://api.github.com/repos/baxterthehacker/public-repo/issues/2/comments',
+              labels:[{
+                url: 'https://api.github.com/repos/baxterthehacker/public-repo/labels/probot:freeze',
+                name: 'probot:freeze',
+                color: 'fc2929'
+              }]}]
           }})) // Q:'label:' + this.labelName
       }
     };
@@ -165,7 +168,7 @@ perform: true
     });
   });
 
-  it('test visitor activation', async () => {
+  it('test scheduled thaw success', async () => {
     await robot.receive({
       event: 'schedule',
       payload: {
@@ -200,6 +203,29 @@ perform: true
     });
   });
 
+  it('test scheduled thaw failure', async () => {
+    github.search.issues = expect.createSpy().andReturn(Promise.resolve({
+      data:{
+        total_count: 0,
+        incomplete_results: false,
+        items: []
+      }
+    })); // Q:'label:' + this.labelName
+
+    await robot.receive({
+      event: 'schedule',
+      payload: {
+        action: 'repository',
+        repository: {
+          owner: {
+            login:'baxterthehacker'
+          },
+          name:'public-repo'
+        },
+        installation: {
+          id: 13055
+        }}});
+  });
   it('test valid comments', async () => {
     const defaultFreezeDuration = 7;
     const validMessages = [


### PR DESCRIPTION
This PR will investigate the various problems with waking threads on schedule. Some discussion on potential problems are outlined in https://github.com/jbjonesjr/probot-snooze/issues/8#issuecomment-323789453 ,  but will potential causes below:

> * The comment body is somehow malformed and I can't get the **last snooze command** even though you issued one. This is a corrupted record in terms of snooze's ability to read it. Figure out why I corrupted it, and how I should be more flexible in my reading.
> * If it's a really long thread. #2 reminds me that I don't yet handle pagination. If it is a 100+ comment issue, and you snoozed it in the `2nd page` of comments, I won't iterate/find it, and could create this situation.


closes #8 

ChangeLog:
- added test to ensure that if no snoozed issues are found, no errors are thrown
  - added logging statement to this effect
  - used property `total_count` vs an empty array to check for this to be more verbose, not rely on side effects on empty looping
- added check to log to log if a snoozed thread was found with no snooze command. This should at least let us know what threads are failing
