### PR TITLE
Use require to load defaults once

### DIFF
--- a/etc/defaults.json
+++ b/etc/defaults.json
@@ -1,7 +1,0 @@
-{
-  "probotUsername" : "probot-snooze[bot]",
-  "labelName" : "probot:snooze",
-  "labelColor" : "gray",
-  "defaultFreezeDuration" : 7,
-  "sampleFormat" : "@probot, freeze this thread until 2100-01-01 with 'A message I\\'ll respond with'"
-}

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const createScheduler = require('probot-scheduler');
 const Freeze = require('./lib/freeze');
 const formatParser = require('./lib/format-parser');
 const githubHelper = require('./lib/github-helper');
-const defaults = require('./etc/defaults');
+const defaults = require('./lib/defaults');
 
 /* Configuration Variables */
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-const fs = require('fs');
 const createScheduler = require('probot-scheduler');
 const Freeze = require('./lib/freeze');
 const formatParser = require('./lib/format-parser');
 const githubHelper = require('./lib/github-helper');
+const defaults = require('./etc/defaults');
 
 /* Configuration Variables */
 
@@ -14,7 +14,7 @@ module.exports = robot => {
   robot.on('schedule.repository', handleThaw);
 
   async function installationEvent(context) {
-    const config = await context.config('probot-snooze.yml', JSON.parse(fs.readFileSync('./etc/defaults.json', 'utf8')));
+    const config = await context.config('probot-snooze.yml', defaults);
 
     context.github.issues.getLabel(context.repositories_added[0]({
       name: config.labelName}).catch(() => {
@@ -26,7 +26,7 @@ module.exports = robot => {
   }
 
   async function handleFreeze(context) {
-    const config = await context.config('probot-snooze.yml', JSON.parse(fs.readFileSync('./etc/defaults.json', 'utf8')));
+    const config = await context.config('probot-snooze.yml', defaults);
     const freeze = new Freeze(context.github, config);
 
     const comment = context.payload.comment;
@@ -40,7 +40,7 @@ module.exports = robot => {
   }
 
   async function handleThaw(context) {
-    const config = await context.config('probot-snooze.yml', JSON.parse(fs.readFileSync('./etc/defaults.json', 'utf8')));
+    const config = await context.config('probot-snooze.yml', defaults);
 
     const freeze = new Freeze(context.github, config);
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,0 +1,7 @@
+module.exports = {
+  probotUsername: (process.env.APP_NAME || 'probot-snooze') + '[bot]',
+  labelName: 'probot:snooze',
+  labelColor: 'gray',
+  defaultFreezeDuration: 7,
+  sampleFormat: '@probot, freeze this thread until 2100-01-01 with "A message I\'ll respond with"'
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const expect = require('expect');
 const {createRobot} = require('probot');
 const plugin = require('..');
@@ -224,7 +223,7 @@ perform: true
       {msg:'Thanks for looking into this.\n\nSo i\'m out of office for the next three weeks. I\'m going to snooze this until I get back on 07/21/17.', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('next three weeks'))}}
     ];
 
-    const freeze = new Freeze(github, JSON.parse(fs.readFileSync('./etc/defaults.json', 'utf8')));
+    const freeze = new Freeze(github, require('../lib/defaults'));
 
     validMessages.forEach(obj => {
       const comment = {
@@ -248,7 +247,7 @@ perform: true
     {msg:'snooze until 07/11/17 at 14:00, and "bug Seth"', props:{assignee: 'baxterthehacker', message: 'bug Seth', unfreezeMoment: moment(chrono.parseDate('07/11/17 at 14:00'))}},
     {msg:'hey @probot, snooze this issue', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment().add(defaultFreezeDuration, 'days').format()}}
       ];
-    const freeze = new Freeze(github, JSON.parse(fs.readFileSync('./etc/defaults.json', 'utf8')));
+    const freeze = new Freeze(github, require('../lib/defaults'));
 
     msgs.forEach(obj => {
       const comment = {


### PR DESCRIPTION
This updates the loading of defaults to be called once using `require` instead of with `JSON.parse(fs.readFileSync(xxx))`. It's a little bit cleaner looking, and avoids a synchronous filesystem read on every event.