### PR TITLE
Add repo to search query

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,8 +43,10 @@ module.exports = robot => {
     const config = await context.config('probot-snooze.yml', JSON.parse(fs.readFileSync('./etc/defaults.json', 'utf8')));
 
     const freeze = new Freeze(context.github, config);
+    const {owner, repo} = context.repo();
+    const q = `label:"${freeze.config.labelName}" repo:${owner}/${repo}`;
 
-    context.github.search.issues({q:'label:' + freeze.config.labelName, repo:context.repo().full_name}).then(resp => {
+    context.github.search.issues({q}).then(resp => {
       resp.data.items.forEach(issue => {
         context.github.issues.getComments(githubHelper.parseCommentURL(issue.comments_url)).then(resp => {
           return freeze.getLastFreeze(resp.data);


### PR DESCRIPTION
`repo` was being passed as a request parameter to the search, but it actually needs to be part of the search query. Without it, the search was returning all issues for the entire installation, which means every frozen issue was being checked against each repository configuration.