### PR TITLE
Fix comment not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = robot => {
         context.github.issues.getComments(githubHelper.parseCommentURL(issue.comments_url)).then(resp => {
           return freeze.getLastFreeze(resp.data);
         }).then(lastFreezeComment => {
-          if (lastFreezeComment && freeze.unfreezable(lastFreezeComment)) {
+          if (freeze.unfreezable(lastFreezeComment)) {
             freeze.unfreeze(issue, formatParser.propFromComment(lastFreezeComment));
           }
         });

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = robot => {
         context.github.issues.getComments(githubHelper.parseCommentURL(issue.comments_url)).then(resp => {
           return freeze.getLastFreeze(resp.data);
         }).then(lastFreezeComment => {
-          if (freeze.unfreezable(lastFreezeComment)) {
+          if (lastFreezeComment && freeze.unfreezable(lastFreezeComment)) {
             freeze.unfreeze(issue, formatParser.propFromComment(lastFreezeComment));
           }
         });

--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -32,15 +32,9 @@ module.exports = class Freeze {
   }
 
   getLastFreeze(comments) {
-    let mainComment = {};
-    comments.reverse().some(comment => {
-      if (comment.user.login === this.config.probotUsername) {
-        mainComment = comment;
-        return true;
-      }
-      return false;
+    return comments.reverse().find(comment => {
+      return comment.user.login === this.config.probotUsername;
     });
-    return mainComment;
   }
 
   freeze(context, props) {

--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -51,7 +51,8 @@ module.exports = class Freeze {
     }));
 
     this.github.issues.createComment(context.issue({
-      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around ' + props.unfreezeMoment.calendar() + ' :clock1: ' +
+      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around ' +
+      moment(props.unfreezeMoment).calendar() + ' :clock1: ' +
       '<!-- ' + JSON.stringify(props) + '-->'
     }));
   }


### PR DESCRIPTION
This fixes #8 by:

1. Fixing an error I was getting with freezing due calling `.calendar()` on a plain ol' string, preventing the app from leaving its special comment with the freeze attributes
2. Skipping unfreeze if no freeze comment is found