### PR TITLE
Use probot-metadata for storing snooze config

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = robot => {
       // Issue objects from the API don't include owner/repo params, so
       // setting them here with `context.repo` so we don't have to worry
       // about it later. :/
-      return freeze.checkUnfreeze(context.repo(issue));
+      return freeze.checkUnfreeze(context, context.repo(issue));
     }));
     robot.log('scheduled thaw run complete');
   }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 const fs = require('fs');
 const createScheduler = require('probot-scheduler');
 const Freeze = require('./lib/freeze');
-const formatParser = require('./lib/format-parser');
-const githubHelper = require('./lib/github-helper');
 
 /* Configuration Variables */
 
@@ -46,17 +44,14 @@ module.exports = robot => {
     const {owner, repo} = context.repo();
     const q = `label:"${freeze.config.labelName}" repo:${owner}/${repo}`;
 
-    context.github.search.issues({q}).then(resp => {
-      resp.data.items.forEach(issue => {
-        context.github.issues.getComments(githubHelper.parseCommentURL(issue.comments_url)).then(resp => {
-          return freeze.getLastFreeze(resp.data);
-        }).then(lastFreezeComment => {
-          if (freeze.unfreezable(lastFreezeComment)) {
-            freeze.unfreeze(issue, formatParser.propFromComment(lastFreezeComment));
-          }
-        });
-      });
-    });
-    console.log('scheduled thaw run complete');
+    const resp = await context.github.search.issues({q});
+
+    await Promise.all(resp.data.items.map(issue => {
+      // Issue objects from the API don't include owner/repo params, so
+      // setting them here with `context.repo` so we don't have to worry
+      // about it later. :/
+      return freeze.checkUnfreeze(context.repo(issue));
+    }));
+    robot.log('scheduled thaw run complete');
   }
 };

--- a/lib/format-parser.js
+++ b/lib/format-parser.js
@@ -14,14 +14,5 @@ module.exports = {
       return (typeof match[2] === 'undefined' ? match[1] : match[2]);
     }
     return 'Hey, we\'re back awake!';
-  },
-
-  propFromComment(comment) {
-    const match = comment.body.match('.*<!-- (props = )?(.*)-->');
-    if (match !== null) {
-      return JSON.parse(match[2]);
-    }
-    return {};
   }
-
 };

--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -42,8 +42,7 @@ module.exports = class Freeze {
       labels.push(this.config.labelName);
     }
 
-    const kv = metadata(context.github, context.issue(), process.env.APP_ID);
-    await kv.set('snooze', props);
+    await metadata(context).set(props);
 
     await this.github.issues.edit(context.issue({
       state: 'closed',
@@ -56,9 +55,8 @@ module.exports = class Freeze {
     }));
   }
 
-  async checkUnfreeze(issue) {
-    const kv = metadata(this.github, issue, process.env.APP_ID);
-    const props = await kv.get('snooze');
+  async checkUnfreeze(context, issue) {
+    const props = await metadata(context, issue).get();
 
     if (moment(props.unfreezeMoment) < moment()) {
       return this.unfreeze(issue, props);

--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -1,5 +1,6 @@
 const moment = require('moment');
 const Bravey = require('bravey');
+const metadata = require('probot-metadata');
 const formatParser = require('./format-parser');
 const GitHubHelper = require('./github-helper');
 
@@ -37,7 +38,7 @@ module.exports = class Freeze {
     });
   }
 
-  freeze(context, props) {
+  async freeze(context, props) {
     const labels = context.payload.issue.labels;
     if (GitHubHelper.isLabelOnIssue(
       context.payload.issue,
@@ -45,15 +46,17 @@ module.exports = class Freeze {
       labels.push(this.config.labelName);
     }
 
-    this.github.issues.edit(context.issue({
+    const kv = metadata(context.github, context.issue(), process.env.APP_ID);
+    await kv.set('snooze', props);
+
+    await this.github.issues.edit(context.issue({
       state: 'closed',
       labels
     }));
 
-    this.github.issues.createComment(context.issue({
+    await this.github.issues.createComment(context.issue({
       body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around ' +
-      moment(props.unfreezeMoment).calendar() + ' :clock1: ' +
-      '<!-- ' + JSON.stringify(props) + '-->'
+      moment(props.unfreezeMoment).calendar() + ' :clock1: '
     }));
   }
 

--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -18,10 +18,6 @@ module.exports = class Freeze {
     return this.nlp.test(comment.body) !== false;
   }
 
-  unfreezable(comment) {
-    return moment(formatParser.propFromComment(comment).unfreezeMoment) < moment();
-  }
-
   propsHelper(assignee, commentBody) {
     const pd = formatParser.parseDateFromComment(commentBody);
 
@@ -60,7 +56,16 @@ module.exports = class Freeze {
     }));
   }
 
-  unfreeze(issue, props) {
+  async checkUnfreeze(issue) {
+    const kv = metadata(this.github, issue, process.env.APP_ID);
+    const props = await kv.get('snooze');
+
+    if (moment(props.unfreezeMoment) < moment()) {
+      return this.unfreeze(issue, props);
+    }
+  }
+
+  async unfreeze(issue, props) {
     const labels = issue.labels;
     const frozenLabel = labels.find(label => {
       return label.name === this.config.labelName;
@@ -68,14 +73,14 @@ module.exports = class Freeze {
     const pos = labels.indexOf(frozenLabel);
     labels.splice(pos, 1);
 
-    this.github.issues.edit(Object.assign(GitHubHelper.parseCommentURL(issue.comments_url), {
-      state: 'open',
-      labels
-    }));
+    const {owner, repo, number} = issue;
 
-    this.github.issues.createComment(Object.assign(GitHubHelper.parseCommentURL(issue.comments_url), {
+    await this.github.issues.edit({owner, repo, number, labels, state: 'open'});
+
+    await this.github.issues.createComment({
+      owner, repo, number,
       body: ':wave: @' + props.assignee + ', ' + props.message
-    }));
+    });
   }
 
   getSnoozeBravey() {

--- a/lib/github-helper.js
+++ b/lib/github-helper.js
@@ -1,22 +1,8 @@
 module.exports = {
-  parseCommentURL(url) {
-    const match = url.match('https://api.github.com/repos/(.*)/(.*)/issues/(.*)/comments');
-    if (match === null) {
-      return {};
-    } else {
-      return {
-        owner:match[1],
-        repo:match[2],
-        number:match[3]
-      };
-    }
-  },
-
   isLabelOnIssue(issue, labelName) {
     const currentLabels = issue.labels.find(elm => {
       return typeof (elm) === 'object' && Object.prototype.hasOwnProperty.call(elm, 'name') && elm.name === labelName;
     });
     return currentLabels;
   }
-
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bravey": "^0.1.2",
     "moment": "^2.18.1",
     "probot": "0.9.1",
+    "probot-metadata": "github:probot/metadata",
     "probot-scheduler": "1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "chrono-node": "^1.3.4",
     "moment": "^2.18.1",
     "probot": "^0.11.0",
-    "probot-metadata": "github:probot/metadata",
+    "probot-metadata": "^1.0.0",
     "probot-scheduler": "1.0.2"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+process.env.APP_ID = 1;
+
 const fs = require('fs');
 const expect = require('expect');
 const {createRobot} = require('probot');
@@ -53,7 +55,10 @@ perform: true
         createComment: expect.createSpy(),
         getLabel: null, //  Name: freeze.labelName
         createLabel: expect.createSpy(), // Name: freeze.config.labelName,          color: freeze.config.labelColor
-        edit: expect.createSpy()
+        edit: expect.createSpy(),
+        get: expect.createSpy().andReturn(Promise.resolve({data: {
+          body: 'hello world'
+        }}))
       },
       search: {
         issues: expect.createSpy().andReturn(Promise.resolve({
@@ -109,7 +114,7 @@ perform: true
       repo: 'public-repo',
       path: '.github/probot-snooze.yml'
     });
-    expect(github.issues.edit({
+    expect(github.issues.edit).toHaveBeenCalledWith({
       number:2,
       owner: 'baxterthehacker',
       repo: 'public-repo',
@@ -120,14 +125,26 @@ perform: true
         color: 'fc2929'
       },
         'probot:freeze']
-    }));
+    });
 
     expect(github.issues.createComment).toHaveBeenCalledWith({
       number: 2,
       owner: 'baxterthehacker',
       repo: 'public-repo',
-      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2017 :clock1: ' +
-        '<!-- ' + JSON.stringify({assignee:'baxterthehacker', unfreezeMoment :chrono.parseDate('July 1, 2017 13:30'), message:'Hey, we\'re back awake!'}) + '-->'
+      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2017 :clock1: '
+    });
+
+    const params = {
+      assignee:'baxterthehacker',
+      unfreezeMoment :chrono.parseDate('July 1, 2017 13:30'),
+      message:'Hey, we\'re back awake!'
+    };
+
+    expect(github.issues.edit).toHaveBeenCalledWith({
+      owner: 'baxterthehacker',
+      repo: 'public-repo',
+      number: 2,
+      body: `hello world\n\n<!-- probot = {"1":{"snooze":${JSON.stringify(params)}}} -->`
     });
   });
 
@@ -160,8 +177,20 @@ perform: true
       number:2,
       owner: 'baxterthehacker',
       repo: 'public-repo',
-      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2017 :clock1: ' +
-        '<!-- ' + JSON.stringify({assignee:'baxterthehacker', unfreezeMoment :chrono.parseDate('July 1, 2017 13:30'), message:'Hey, we\'re back awake!'}) + '-->'
+      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2017 :clock1: '
+    });
+
+    const params = {
+      assignee:'baxterthehacker',
+      unfreezeMoment :chrono.parseDate('July 1, 2017 13:30'),
+      message:'Hey, we\'re back awake!'
+    };
+
+    expect(github.issues.edit).toHaveBeenCalledWith({
+      owner: 'baxterthehacker',
+      repo: 'public-repo',
+      number: 2,
+      body: `hello world\n\n<!-- probot = {"1":{"snooze":${JSON.stringify(params)}}} -->`
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,3 @@
-process.env.APP_ID = 1;
-
 const fs = require('fs');
 const expect = require('expect');
 const {createRobot} = require('probot');
@@ -48,7 +46,7 @@ perform: true
       search: {
         issues: expect.createSpy().andReturn(Promise.resolve({
           data:{items: [{
-            body: 'hello world\n\n<!-- probot = {"1":{"snooze":{"assignee":"baxterthehacker","unfreezeMoment":"2017-07-01T17:30:00.000Z","message":"Hey, we\'re back awake!"}}} -->',
+            body: 'hello world\n\n<!-- probot = {"1":{"assignee":"baxterthehacker","unfreezeMoment":"2017-07-01T17:30:00.000Z","message":"Hey, we\'re back awake!"}} -->',
             number: 2,
             labels:[{
               url: 'https://api.github.com/repos/baxterthehacker/public-repo/labels/probot:freeze',
@@ -63,6 +61,8 @@ perform: true
     robot.auth = () => Promise.resolve(github);
 
     plugin(robot);
+
+    commentEvent.payload.installation.id = 1;
   });
 
   it('resolves timezone issues with chrono-node', async () => {
@@ -131,7 +131,7 @@ perform: true
       owner: 'baxterthehacker',
       repo: 'public-repo',
       number: 2,
-      body: `hello world\n\n<!-- probot = {"1":{"snooze":${JSON.stringify(params)}}} -->`
+      body: `hello world\n\n<!-- probot = {"1":${JSON.stringify(params)}} -->`
     });
   });
 
@@ -177,7 +177,7 @@ perform: true
       owner: 'baxterthehacker',
       repo: 'public-repo',
       number: 2,
-      body: `hello world\n\n<!-- probot = {"1":{"snooze":${JSON.stringify(params)}}} -->`
+      body: `hello world\n\n<!-- probot = {"1":${JSON.stringify(params)}} -->`
     });
   });
 
@@ -193,7 +193,7 @@ perform: true
           name:'public-repo'
         },
         installation: {
-          id: 13055
+          id: 1
         }}});
     expect(github.repos.getContent).toHaveBeenCalledWith({
       owner: 'baxterthehacker',

--- a/test/index.js
+++ b/test/index.js
@@ -37,21 +37,6 @@ perform: true
           }}))
       },
       issues: {
-        getComments: expect.createSpy().andReturn(Promise.resolve(
-          {data: [{
-            body:'comment 1',
-            user: {
-              login:'baxterthehacker'
-            },
-            name:'public-repo'
-          }, {
-            body:'@probot, we should snooze this for a while, until July 1, 2017 13:30 <!-- {"assignee":"baxterthehacker","unfreezeMoment":"2017-07-01T17:30:00.000Z","message":"Hey, we\'re back awake!"}-->',
-            user: {
-              login:'probot-snooze[bot]'
-            },
-            name:'public-repo'}]
-          }
-        )), // GithubHelper.commentUrlToIssueRequest(issue.comments_url)
         createComment: expect.createSpy(),
         getLabel: null, //  Name: freeze.labelName
         createLabel: expect.createSpy(), // Name: freeze.config.labelName,          color: freeze.config.labelColor
@@ -62,7 +47,9 @@ perform: true
       },
       search: {
         issues: expect.createSpy().andReturn(Promise.resolve({
-          data:{items: [{comments_url:'https://api.github.com/repos/baxterthehacker/public-repo/issues/2/comments',
+          data:{items: [{
+            body: 'hello world\n\n<!-- probot = {"1":{"snooze":{"assignee":"baxterthehacker","unfreezeMoment":"2017-07-01T17:30:00.000Z","message":"Hey, we\'re back awake!"}}} -->',
+            number: 2,
             labels:[{
               url: 'https://api.github.com/repos/baxterthehacker/public-repo/labels/probot:freeze',
               name: 'probot:freeze',
@@ -213,18 +200,17 @@ perform: true
       repo: 'public-repo',
       path: '.github/probot-snooze.yml'
     });
-
     expect(github.issues.edit).toHaveBeenCalledWith({
       labels: [],
       owner: 'baxterthehacker',
       repo: 'public-repo',
-      number: '2',
+      number: 2,
       state: 'open'
     });
     expect(github.issues.createComment).toHaveBeenCalledWith({
       owner: 'baxterthehacker',
       repo: 'public-repo',
-      number: '2',
+      number: 2,
       body: ':wave: @baxterthehacker, Hey, we\'re back awake!'
     });
   });


### PR DESCRIPTION
This is an update to https://github.com/bkeepers/probot-snooze/pull/1, which is a spike to use the new [probot-metadata](https://github.com/probot/metadata) to store the snooze config for each issue.

- [x] Update after probot-metadata is published to npm