### PR TITLE
Fix lint errors

### DIFF
--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -93,10 +93,10 @@ module.exports = class Freeze {
     commandEntity.addMatch('freeze', 'freeze');
 
     nlp.addEntity(commandEntity);
-    
-    // Regex Entity parsing does not currently work. It causes a recursive f(x) that crashes node. That's why 
+
+    // Regex Entity parsing does not currently work. It causes a recursive f(x) that crashes node. That's why
     const responseEntity = new Bravey.RegexEntityRecognizer('reopen_text');
-    responseEntity.addMatch(new RegExp('====== (.*) ======='), (match) => {
+    responseEntity.addMatch(new RegExp('====== (.*) ======='), match => {
       return match;
     });
 


### PR DESCRIPTION
Fixes these errors from running `npm test`:

```
  lib/freeze.js:96:1
  ✖  96:1    Trailing spaces not allowed.                             no-trailing-spaces
  ✖  97:110  Trailing spaces not allowed.                             no-trailing-spaces
  ✖  99:64   Unexpected parentheses around single function argument.  arrow-parens

  1 warning
  3 errors
```

@jbjonesjr any idea why tests aren't running?